### PR TITLE
Temporary hacks to make it work with rules_ios

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,10 +19,11 @@ load(
     "@build_bazel_rules_apple//apple:versioning.bzl",
     "apple_bundle_version",
 )
-load(
-    "@com_github_bazelbuild_buildtools//buildifier:def.bzl",
-    "buildifier",
-)
+# FIX-ME: Bring this back after resolving issues with loading from rules_ios
+# load(
+#     "@com_github_bazelbuild_buildtools//buildifier:def.bzl",
+#     "buildifier",
+# )
 load(
     "//third_party:repositories.bzl",
     "namespaced_name",
@@ -135,9 +136,10 @@ macos_application(
     deps = [":XCHammerSources", ":XCHammerSourcesXcodeConfig"],
 )
 
-buildifier(
-    name = "buildifier",
-)
+# FIX-ME: Bring this back after resolving issues with loading from rules_ios
+# buildifier(
+#     name = "buildifier",
+# )
 
 script_base = "$SRCROOT/tools/instrumentation_helpers"
 

--- a/BazelExtensions/xcodeproject.bzl
+++ b/BazelExtensions/xcodeproject.bzl
@@ -131,7 +131,7 @@ def _xcode_project_impl(ctx):
             "--bazel",
             ctx.attr.bazel
             if ctx.attr.bazel[0] == "/"
-            else "\$SRCROOT/" + ctx.attr.bazel,
+            else "\\$SRCROOT/" + ctx.attr.bazel,
             "--xcode_project_rule_info",
             xchammer_info_json.path,
             "; ditto " + project_name + " " + ctx.outputs.out.path,
@@ -177,7 +177,7 @@ def _install_xcode_project_impl(ctx):
         # This is kind of a hack for reference bazel relative to the source
         # directory, as bazel_build_settings.py doesn't sub Xcode build
         # settings.
-        "sed -i '' \"s,\$SRCROOT,$SRCROOT,g\" "
+        "sed -i '' \"s,\\$SRCROOT,$SRCROOT,g\" "
         + output_proj
         + "/XCHammerAssets/bazel_build_settings.py",
         # Ensure the `external` symlink points to output_base/external

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -83,12 +83,14 @@ go_rules_dependencies()
 
 go_register_toolchains()
 
-http_archive(
-    name = "com_github_bazelbuild_buildtools",
-    strip_prefix = "buildtools-0.25.0",
-    url = "https://github.com/bazelbuild/buildtools/archive/0.25.0.zip",
-)
+# FIX-ME: Conflicts with how rules_ios loads buidlifier, bring this back or remote it after
+# finding the root cause
+# http_archive(
+#     name = "com_github_bazelbuild_buildtools",
+#     strip_prefix = "buildtools-0.25.0",
+#     url = "https://github.com/bazelbuild/buildtools/archive/0.25.0.zip",
+# )
 
-load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_dependencies")
+# load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_dependencies")
 
-buildifier_dependencies()
+# buildifier_dependencies()

--- a/third_party/repositories.bzl
+++ b/third_party/repositories.bzl
@@ -258,7 +258,7 @@ def xchammer_dependencies():
     namespaced_git_repository(
         name = "Tulsi",
         remote = "https://github.com/bazel-ios/tulsi.git",
-        commit = "72adb78843fb6d04088984d889bf634ca1948d7d",
+        tag = "rules_ios-0.0.1",
         patch_cmds = [
             """
          sed -i '' 's/\\:__subpackages__/visibility\\:public/g' src/TulsiGenerator/BUILD
@@ -273,7 +273,7 @@ def xchammer_dependencies():
     new_git_repository(
         name = "xchammer_tulsi_aspects",
         remote = "https://github.com/bazel-ios/tulsi.git",
-        commit = "72adb78843fb6d04088984d889bf634ca1948d7d",
+        tag = "rules_ios-0.0.1",
         strip_prefix="src/TulsiGenerator/Bazel",
         build_file_content="exports_files(['tulsi'])"
     )

--- a/third_party/repositories.bzl
+++ b/third_party/repositories.bzl
@@ -255,27 +255,25 @@ def xchammer_dependencies():
         ]),
     )
 
-
     namespaced_git_repository(
         name = "Tulsi",
-        remote = "https://github.com/pinterest/tulsi.git",
-        commit = "feba74a99096757bd719e9361caaaf3f2bd5387c",
+        remote = "https://github.com/bazel-ios/tulsi.git",
+        commit = "72adb78843fb6d04088984d889bf634ca1948d7d",
         patch_cmds = [
             """
-         sed -i '' 's/\:__subpackages__/visibility\:public/g' src/TulsiGenerator/BUILD
+         sed -i '' 's/\\:__subpackages__/visibility\\:public/g' src/TulsiGenerator/BUILD
          """,
             """
-         sed -i '' 's/RunLoopMode\.defaultRunLoopMode/RunLoop\.Mode\.`default`/g' src/TulsiGenerator/ProcessRunner.swift
+         sed -i '' 's/RunLoopMode\\.defaultRunLoopMode/RunLoop\\.Mode\\.`default`/g' src/TulsiGenerator/ProcessRunner.swift
          """,
         ],
     )
 
-    # This is a hack for XCHammer development, but is how XCHammer is imported 
-    # into a workspace as a binary build
+    # FIX-ME: Point to 'master' instead of 'thiago/rules-ios-xchammer-1' after resolving issues
     new_git_repository(
         name = "xchammer_tulsi_aspects",
-        remote = "https://github.com/pinterest/tulsi.git",
-        commit = "6302ee15a49a93fcaaff75e1fcd235fc87ac2ec8",
+        remote = "https://github.com/bazel-ios/tulsi.git",
+        commit = "72adb78843fb6d04088984d889bf634ca1948d7d",
         strip_prefix="src/TulsiGenerator/Bazel",
         build_file_content="exports_files(['tulsi'])"
     )


### PR DESCRIPTION
Requires: https://github.com/bazel-ios/tulsi/pull/1

Disables some things to make it work with `rules_ios`: https://github.com/bazel-ios/rules_ios/pull/443

- [x] Bump Tulsi to latest git tag in `rules-ios-xchammer` before landing this