### PR TITLE
Pure Xcode: Supplement vfs with -F

### DIFF
--- a/Sources/XCHammer/XCBuildSettings.swift
+++ b/Sources/XCHammer/XCBuildSettings.swift
@@ -177,6 +177,7 @@ enum XCSettingCodingKey: String, CodingKey {
     // Hammer Rules
     case codeSignEntitlementsFile = "HAMMER_ENTITLEMENTS_FILE"
     case mobileProvisionProfileFile = "HAMMER_PROFILE_FILE"
+    case frameworkvfsoverlay = "RULES_IOS_VFS_OVERLAY"
     case diagnosticFlags = "HAMMER_DIAGNOSTIC_FLAGS"
     case isBazel = "HAMMER_IS_BAZEL"
     case tulsiWR = "TULSI_WR"
@@ -220,6 +221,7 @@ struct XCBuildSettings: Encodable {
     var codeSigningStyle: First<String>? = First("manual")
     var mobileProvisionProfileFile: First<String>?
     var codeSignEntitlementsFile: First<String>?
+    var frameworkvfsoverlay: First<String>?
     var moduleMapFile: First<String>?
     var moduleName: First<String>?
     // Disable Xcode derived headermaps, be explicit to avoid divergence
@@ -288,6 +290,7 @@ struct XCBuildSettings: Encodable {
         try codeSigningIdentity.map { try container.encode($0.v, forKey: .codeSigningIdentity) }
         try codeSigningStyle.map { try container.encode($0.v, forKey: .codeSigningStyle) }
         try mobileProvisionProfileFile.map { try container.encode($0.v, forKey: .mobileProvisionProfileFile) }
+        try frameworkvfsoverlay.map { try container.encode($0.v, forKey: .frameworkvfsoverlay) }
         try codeSignEntitlementsFile.map { try container.encode($0.v, forKey: .codeSignEntitlementsFile) }
         try moduleMapFile.map { try container.encode($0.v, forKey: .moduleMapFile) }
         try moduleName.map { try container.encode($0.v, forKey: .moduleName) }
@@ -346,6 +349,7 @@ extension XCBuildSettings: Monoid {
             codeSigningStyle: lhs.codeSigningStyle <> rhs.codeSigningStyle,
             mobileProvisionProfileFile: lhs.mobileProvisionProfileFile <> rhs.mobileProvisionProfileFile,
             codeSignEntitlementsFile: lhs.codeSignEntitlementsFile <> rhs.codeSignEntitlementsFile,
+            frameworkvfsoverlay: lhs.frameworkvfsoverlay <> rhs.frameworkvfsoverlay,
             moduleMapFile: lhs.moduleMapFile <> rhs.moduleMapFile,
             moduleName: lhs.moduleName <> rhs.moduleName,
             useHeaderMap: lhs.useHeaderMap <> rhs.useHeaderMap,

--- a/Sources/XCHammer/XCBuildSettings.swift
+++ b/Sources/XCHammer/XCBuildSettings.swift
@@ -136,7 +136,7 @@ enum XCSettingCodingKey: String, CodingKey {
     case swiftc = "SWIFT_EXEC"
     case ld = "LD"
     case libtool = "LIBTOOL"
-    case copts = "OTHER_CFLAGS"
+    case copts = "WARNING_CFLAGS"
     case ldFlags = "OTHER_LDFLAGS"
     case productName = "PRODUCT_NAME"
     case moduleName = "PRODUCT_MODULE_NAME"
@@ -177,7 +177,8 @@ enum XCSettingCodingKey: String, CodingKey {
     // Hammer Rules
     case codeSignEntitlementsFile = "HAMMER_ENTITLEMENTS_FILE"
     case mobileProvisionProfileFile = "HAMMER_PROFILE_FILE"
-    case frameworkvfsoverlay = "RULES_IOS_VFS_OVERLAY"
+    case objcFrameworkVFSOverlay = "RULES_IOS_SWIFT_VFS_OVERLAY"
+    case swiftFrameworkVFSOverlay = "RULES_IOS_OBJC_VFS_OVERLAY"
     case diagnosticFlags = "HAMMER_DIAGNOSTIC_FLAGS"
     case isBazel = "HAMMER_IS_BAZEL"
     case tulsiWR = "TULSI_WR"
@@ -221,7 +222,8 @@ struct XCBuildSettings: Encodable {
     var codeSigningStyle: First<String>? = First("manual")
     var mobileProvisionProfileFile: First<String>?
     var codeSignEntitlementsFile: First<String>?
-    var frameworkvfsoverlay: First<String>?
+    var objcFrameworkVFSOverlay: First<String>?
+    var swiftFrameworkVFSOverlay: First<String>?
     var moduleMapFile: First<String>?
     var moduleName: First<String>?
     // Disable Xcode derived headermaps, be explicit to avoid divergence
@@ -290,7 +292,8 @@ struct XCBuildSettings: Encodable {
         try codeSigningIdentity.map { try container.encode($0.v, forKey: .codeSigningIdentity) }
         try codeSigningStyle.map { try container.encode($0.v, forKey: .codeSigningStyle) }
         try mobileProvisionProfileFile.map { try container.encode($0.v, forKey: .mobileProvisionProfileFile) }
-        try frameworkvfsoverlay.map { try container.encode($0.v, forKey: .frameworkvfsoverlay) }
+        try objcFrameworkVFSOverlay.map { try container.encode($0.v, forKey: .objcFrameworkVFSOverlay) }
+        try swiftFrameworkVFSOverlay.map { try container.encode($0.v, forKey: .swiftFrameworkVFSOverlay) }
         try codeSignEntitlementsFile.map { try container.encode($0.v, forKey: .codeSignEntitlementsFile) }
         try moduleMapFile.map { try container.encode($0.v, forKey: .moduleMapFile) }
         try moduleName.map { try container.encode($0.v, forKey: .moduleName) }
@@ -349,7 +352,8 @@ extension XCBuildSettings: Monoid {
             codeSigningStyle: lhs.codeSigningStyle <> rhs.codeSigningStyle,
             mobileProvisionProfileFile: lhs.mobileProvisionProfileFile <> rhs.mobileProvisionProfileFile,
             codeSignEntitlementsFile: lhs.codeSignEntitlementsFile <> rhs.codeSignEntitlementsFile,
-            frameworkvfsoverlay: lhs.frameworkvfsoverlay <> rhs.frameworkvfsoverlay,
+            objcFrameworkVFSOverlay: lhs.objcFrameworkVFSOverlay <> rhs.objcFrameworkVFSOverlay,
+            swiftFrameworkVFSOverlay: lhs.swiftFrameworkVFSOverlay <> rhs.swiftFrameworkVFSOverlay,
             moduleMapFile: lhs.moduleMapFile <> rhs.moduleMapFile,
             moduleName: lhs.moduleName <> rhs.moduleName,
             useHeaderMap: lhs.useHeaderMap <> rhs.useHeaderMap,

--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -674,7 +674,10 @@ public class XcodeTarget: Hashable, Equatable {
         return Set(deps)
     }()
 
-    func getVFSPath(_ compilerFlags: String) -> String? {
+    /// Parses out a VFS path
+    /// Takes something like 
+    /// -DSome -vfsoverlay/some/other -DNone and returns the VFS path
+    private func getVFSPath(_ compilerFlags: String) -> String? {
         guard let startIdx = compilerFlags.range(of: "vfsoverlay") else {
             return nil
         }
@@ -723,6 +726,9 @@ public class XcodeTarget: Hashable, Equatable {
             return nil
         }
 
+        let projectConfig = genOptions.config .projects[genOptions.projectName]
+        let generateXcodeTargets = (projectConfig?.generateXcodeSchemes ?? true != false)
+
         var settings = XCBuildSettings()
         self.attributes.keys.sorted(by: { $0.rawValue < $1.rawValue }).forEach { attr in
             let value = self.attributes[attr]!
@@ -742,10 +748,10 @@ public class XcodeTarget: Hashable, Equatable {
                             // replicate frameworks in Xcode, however this
                             // needs to be set at the language level
                             return
-                        } else if opt.hasPrefix("-ivfsoverlay") {
+                        } else if generateXcodeTargets && opt.hasPrefix("-ivfsoverlay") {
                             // Assume using Bazel's VFS is trouble ( FIXME Pure Xcode only )
-                            getVFSPath(opt).map { settings.frameworkvfsoverlay <>= First(subBazelMakeVariables($0, useSRCRoot: true)) }
-                        } else if opt == "-F/build_bazel_rules_ios/frameworks" {
+                            let _ = getVFSPath(opt).map { settings.objcFrameworkVFSOverlay <>= First(subBazelMakeVariables($0, useSRCRoot: true)) }
+                        } else if generateXcodeTargets && opt == "-F/build_bazel_rules_ios/frameworks" {
                             accum.append("-F$BUILT_PRODUCTS_DIR")
                         } else if !opt.isEmpty {
                             accum.append(subBazelMakeVariables(opt, useSRCRoot: true))
@@ -800,6 +806,20 @@ public class XcodeTarget: Hashable, Equatable {
                 break // Logic handled in extractSwiftVersion function since there is a logical order of determining SWIFT_VERSION
             case .swiftc_opts:
                 if let coptsArray = value as? [String] {
+                    let stripSwiftVFSOpt = { (opt: String, idx: Int) -> Bool in
+                        guard generateXcodeTargets else {
+                            return false
+                        }
+
+                        if opt.hasPrefix("-vfsoverlay") ||
+                            (opt == "-Xfrontend" && coptsArray[idx + 1].hasPrefix("-vfsoverlay")) ||
+                             (idx + 1 < coptsArray.count) && coptsArray[idx + 1].hasPrefix("-vfsoverlay") {
+                            return true
+                        } else if opt == "-Xcc" && coptsArray[idx + 1].hasPrefix("-ivfsoverlay") {
+                            return true
+                        }
+                        return false
+                    }
                     let processedOpts = coptsArray.enumerated().reduce(into: [String]()) {
                         accum, itr in
                         let (idx, opt) = itr
@@ -808,13 +828,10 @@ public class XcodeTarget: Hashable, Equatable {
                         } else if opt == "-index-store-path" || (idx > 0 &&
                             coptsArray[idx - 1] == "-index-store-path") {
                             return
-                        } else if (opt == "-Xfrontend" && coptsArray[idx + 1].hasPrefix("-vfsoverlay")) || (idx + 1 < coptsArray.count) && coptsArray[idx + 1].hasPrefix("-vfsoverlay") {
+                        } else if stripSwiftVFSOpt(opt, idx) {
                             return
-                        } else if opt == "-Xcc" && coptsArray[idx + 1].hasPrefix("-ivfsoverlay") {
-                            return
-                        } else if opt.hasPrefix("-ivfsoverlay") {
-                            // Assume using Bazel's VFS is trouble ( FIXME Pure Xcode only )
-                            getVFSPath(opt).map { settings.frameworkvfsoverlay <>= First(subBazelMakeVariables($0, useSRCRoot: true)) }
+                        } else if generateXcodeTargets && opt.hasPrefix("-ivfsoverlay") {
+                            let _ = getVFSPath(opt).map { settings.swiftFrameworkVFSOverlay <>= First(subBazelMakeVariables($0, useSRCRoot: true)) }
                         } else if opt == "-F/build_bazel_rules_ios/frameworks" {
                             accum.append("-F$BUILT_PRODUCTS_DIR")
                         } else if !opt.isEmpty {
@@ -1625,16 +1642,21 @@ private func makeScripts(for xcodeTarget: XcodeTarget, genOptions: XCHammerGener
         return  ProjectSpec.BuildScript(path: nil, script: processContent, name: "Install VFS")
     }
 
+    func getModuleMapScript() -> ProjectSpec.BuildScript {
+        let xchammerBin = Generator.getXCHammerBinPath(genOptions: genOptions)
+        // Install the module map into the framework _after_ compiling only if it exists
+        let processContent = "[[ -n ${MODULEMAP_FILE:-} ]] || exit 0; rm -rf $TARGET_BUILD_DIR/${PRODUCT_NAME}.framework/Modules/module.modulemap; cp $MODULEMAP_FILE $TARGET_BUILD_DIR/${PRODUCT_NAME}.framework/Modules/module.modulemap"
+        return  ProjectSpec.BuildScript(path: nil, script: processContent, name: "Install module.modulemap")
+    }
+
     func getCodeSignerScript() -> ProjectSpec.BuildScript {
         let codeSignerContent = "$PROJECT_FILE_PATH/" + XCHammerAsset.codesigner.getPath()
         return ProjectSpec.BuildScript(path: nil, script: codeSignerContent, name: "Codesign")
     }
 
-    let basePostScripts: [ProjectSpec.BuildScript] = []
+    let basePostScripts: [ProjectSpec.BuildScript] = xcodeTarget.type == "apple_framework_packaging" ? [getModuleMapScript()] : []
     let postScripts: [ProjectSpec.BuildScript]
-
-    // TODO(rules_ios) make conditional only - probably based on the rule type
-    let basePreScripts: [ProjectSpec.BuildScript] = [getInstallVFSScript()]
+    let preScripts: [ProjectSpec.BuildScript] = xcodeTarget.type == "apple_framework_packaging" ? [getInstallVFSScript()] : []
 
     if xcodeTarget.needsRecursiveExtraction,
         xcodeTarget.mobileProvisionProfileFile != nil,
@@ -1647,7 +1669,7 @@ private func makeScripts(for xcodeTarget: XcodeTarget, genOptions: XCHammerGener
         postScripts = xcodeTarget.type.contains("application") ? [getProcessScript()] : []
     }
 
-    return (basePreScripts, basePostScripts + postScripts)
+    return (preScripts, basePostScripts + postScripts)
 }
 
 

--- a/Sources/XCHammer/main.swift
+++ b/Sources/XCHammer/main.swift
@@ -273,15 +273,15 @@ struct InstallVFSCommand: CommandProtocol {
         guard let targetBuildDir = ProcessInfo.processInfo.environment["TARGET_BUILD_DIR"] else {
             return .failure(.basic("$TARGET_BUILD_DIR not found in the env"))
         }
-        let vfsOverlay = ProcessInfo.processInfo.environment["RULES_IOS_VFS_OVERLAY"]  ?? " "
+        let vfsOverlay = ProcessInfo.processInfo.environment["RULES_IOS_OBJC_VFS_OVERLAY"]
+            ?? ProcessInfo.processInfo.environment["RULES_IOS_SWIFT_VFS_OVERLAY"] ?? ""
         guard let frameworkName =
         ProcessInfo.processInfo.environment["PRODUCT_NAME"] else {
             return .failure(.basic("$PRODUCT_NAME not found in the env"))
         }
 
-        return installVFS(targetBuildDir: Path(targetBuildDir),
-                          frameworkName:frameworkName, compilerFlags:
-                           vfsOverlay)
+        return installVFS(targetBuildDir: Path(targetBuildDir), frameworkName:
+                          frameworkName, vfsPath: vfsOverlay)
     }
 }
 

--- a/Sources/XCHammer/main.swift
+++ b/Sources/XCHammer/main.swift
@@ -273,8 +273,7 @@ struct InstallVFSCommand: CommandProtocol {
         guard let targetBuildDir = ProcessInfo.processInfo.environment["TARGET_BUILD_DIR"] else {
             return .failure(.basic("$TARGET_BUILD_DIR not found in the env"))
         }
-        let otherCFlags = ProcessInfo.processInfo.environment["OTHER_CFLAGS"] ?? " "
-        let otherSwiftFlags = ProcessInfo.processInfo.environment["OTHER_SWIFT_FLAGS"]  ?? " "
+        let vfsOverlay = ProcessInfo.processInfo.environment["RULES_IOS_VFS_OVERLAY"]  ?? " "
         guard let frameworkName =
         ProcessInfo.processInfo.environment["PRODUCT_NAME"] else {
             return .failure(.basic("$PRODUCT_NAME not found in the env"))
@@ -282,7 +281,7 @@ struct InstallVFSCommand: CommandProtocol {
 
         return installVFS(targetBuildDir: Path(targetBuildDir),
                           frameworkName:frameworkName, compilerFlags:
-                           otherCFlags + " " + otherSwiftFlags)
+                           vfsOverlay)
     }
 }
 


### PR DESCRIPTION
Logically `-F$(BUILT_PRODUCTS_DIR)` include provides the identical
functionality as the VFS does in Bazel mode. In other words, the include
and VFS yield the same behavior in clang and swift. WIP state is because
we need make this Pure Xcode only ( actually want it in Bazel mode )

Finally, this allows us to:
- remove https://github.com/bazel-ios/rules_ios/pull/470 altogether
- always compile with `apple.virtualize_frameworks` for CLI builds and
  Xcode builds in Pure Xcode mode