### PR TITLE
Add top level resources to a bundle

### DIFF
--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -1527,7 +1527,7 @@ public class XcodeTarget: Hashable, Equatable {
                         pathsPredicate) }
 
             // Use settings, sources, and deps from the fusable deps
-            sources = fusableDeps.flatMap { $0.xcSources }
+            sources = xcodeTarget.xcResources + fusableDeps.flatMap { $0.xcSources }
             settings = xcodeTarget.settings
                 <> fusableDeps.foldMap { $0.settings }
             if shouldPropagateDeps(forTarget: xcodeTarget) {


### PR DESCRIPTION
Fixes when using resources to directly on a top level bundle. This was
added in rules_apple a few years back