### PR TITLE
Set apple.experimental.tree_artifact_outputs as part of the genearte cmd

### DIFF
--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -134,7 +134,7 @@ enum Generator {
             XCHammerGenerateOptions, projectPath: Path, depsHash: String) -> ProjectSpec.Target {
         let generateCommand: [String]
         if let xcodeProjectRuleInfo = genOptions.xcodeProjectRuleInfo {
-            generateCommand = [genOptions.bazelPath.string, "build" ] +
+            generateCommand = [genOptions.bazelPath.string, "build" ] + ["--define=apple.experimental.tree_artifact_outputs=0"] +
                 xcodeProjectRuleInfo.bazelTargets
         } else {
             // Use whatever command and XCHammer this project was built with

--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -134,7 +134,11 @@ enum Generator {
             XCHammerGenerateOptions, projectPath: Path, depsHash: String) -> ProjectSpec.Target {
         let generateCommand: [String]
         if let xcodeProjectRuleInfo = genOptions.xcodeProjectRuleInfo {
-            generateCommand = [genOptions.bazelPath.string, "build" ] + ["--define=apple.experimental.tree_artifact_outputs=0"] +
+            generateCommand = [
+                genOptions.bazelPath.string,
+                "build",
+                "--define=apple.experimental.tree_artifact_outputs=0",
+            ] +
                 xcodeProjectRuleInfo.bazelTargets
         } else {
             // Use whatever command and XCHammer this project was built with


### PR DESCRIPTION
The proj genearator requires `apple.experimental.tree_artifact_outputs=0` but some repos might set `apple.experimental.tree_artifact_outputs=1` in their `.bazelrc`