### PR TITLE
Add _precompiled_apple_resource_bundle in XcodeTarget.includeTarget

### DIFF
--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -107,6 +107,9 @@ func includeTarget(_ xcodeTarget: XcodeTarget, pathPredicate: (String) -> Bool) 
     if xcodeTarget.type == "swift_runtime_linkopts" {
         return false
     }
+    if xcodeTarget.type == "_precompiled_apple_resource_bundle" {
+        return true
+    }
 
     let implSrcs = getImplSources(xcodeTarget, pathPredicate: pathPredicate)
     if implSrcs.count == 0 {


### PR DESCRIPTION
Without this change precompiled resource bundles from `rules_ios` that don't contain the [expected file types](https://github.com/bazel-ios/xchammer/blob/8dce2aab58ce5e8d607237b8aa1080352c19366a/Sources/XCHammer/XcodeTarget.swift#L74-L81) will be considered as [bundles with empty sources](https://github.com/bazel-ios/xchammer/blob/8dce2aab58ce5e8d607237b8aa1080352c19366a/Sources/XCHammer/XcodeTarget.swift#L111-L114) and not be added to the generated Xcode project.

This will cause compilation issues since there won't be a `.bundle` to be copied to the built products folder when building in pure Xcode mode (i.e. `generate_xcode_schemes = True`)