### PR TITLE
[rules_ios] Collect .a and sdk_frameworks

### DIFF
--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -1255,7 +1255,7 @@ public class XcodeTarget: Hashable, Equatable {
     }()
 
     func extractLibraryDeps(map targetMap: XcodeTargetMap) -> [String] {
-        return transitiveTargets(map: targetMap, predicate: stopAfterNeedsRecursive)
+        return transitiveTargets(map: targetMap, predicate: keepGoing)
             .filter { $0.type == "objc_import" }
             .compactMap { target -> [String]? in
                 guard let archives = target.attributes[.archives] as? [[String: Any]] else {

--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -1268,7 +1268,7 @@ public class XcodeTarget: Hashable, Equatable {
 
     func extractAttributeArray(attr: RuleEntry.Attribute, map targetMap: XcodeTargetMap) -> [String] {
         if needsRecursiveExtraction {
-            return ([self] + transitiveTargets(map: targetMap, predicate: stopAfterNeedsRecursive))
+            return ([self] + transitiveTargets(map: targetMap, predicate: keepGoing))
                 .flatMap { $0.attributes[attr] as? [String] ?? [] }
         } else {
             return attributes[attr] as? [String] ?? []


### PR DESCRIPTION
In order to support `rules_ios` we need to continue to search in these two situations in order [to find .a libs](https://github.com/bazel-ios/xchammer/blob/rules-ios-xchammer/Sources/XCHammer/XcodeTarget.swift#L1257-L1266) and properly pass the [flags to link against sdk_frameworks](https://github.com/bazel-ios/xchammer/blob/rules-ios-xchammer/Sources/XCHammer/XcodeTarget.swift#L1257-L1266)

We're paying with time complexity here for sure, just want to get to something that gives us what is necessary before optimizing
