### PR TITLE
Add uninstall build system cmd

### DIFF
--- a/Sources/XCHammer/XcodeBuildSystemInstaller.swift
+++ b/Sources/XCHammer/XcodeBuildSystemInstaller.swift
@@ -67,7 +67,15 @@ enum XcodeBuildSystemInstaller {
                     return .failure(.basic("Default build system not found at temporary path: \(defaultBsTempPath)"))
                 }
 
-                try FileManager.default.removeItem(atPath: defaultBsOriginalPath)
+                if let _ = try? FileManager.default.destinationOfSymbolicLink(atPath: defaultBsOriginalPath) {
+                    try FileManager.default.removeItem(atPath: defaultBsOriginalPath)
+                } else {
+                    print("warning: symlink to XCHammer build system not found at path: \(defaultBsOriginalPath)")
+                }
+
+                guard FileManager.default.fileExists(atPath: defaultBsTempPath) else {
+                    return .failure(.basic("error: original XCBBuildService build service not found at path '\(defaultBsTempPath)'. Check your Xcode installation."))
+                }
                 try FileManager.default.moveItem(atPath: defaultBsTempPath, toPath: defaultBsOriginalPath)
             }
         } catch {

--- a/Sources/XCHammer/XcodeBuildSystemInstaller.swift
+++ b/Sources/XCHammer/XcodeBuildSystemInstaller.swift
@@ -74,6 +74,7 @@ enum XcodeBuildSystemInstaller {
             return .failure(.basic(error.localizedDescription))
         }
 
+        print("XCHammer build system uninstalled.")
         return .success(())
     }
 

--- a/Sources/XCHammer/XcodeBuildSystemInstaller.swift
+++ b/Sources/XCHammer/XcodeBuildSystemInstaller.swift
@@ -29,9 +29,7 @@ enum XcodeBuildSystemInstaller {
     static func installIfNecessary() -> Result<(), CommandError> {
         let bundle = Bundle.main
         let buildkitBundlePath = bundle.path(forResource: "XCBuildKit", ofType: "bundle")!
-        let xcodeLocatorPath =  buildkitBundlePath + "/xcode-locator"
         let installedAppDir = "/opt/XCBuildKit/XCBuildKit.app"
-        let installedBinPath =  installedAppDir + "/Contents/MacOS/BazelBuildService"
         let plistPath = buildkitBundlePath + "/BuildInfo.plist"
         let pkgVersion = getVersion(path: plistPath)
 
@@ -39,37 +37,8 @@ enum XcodeBuildSystemInstaller {
         // it's installed
         var hasUnlinkedXcodes = false
 
-        let xcodeLocatorCmd = xcodeLocatorPath + " 2>&1"
         do {
-            let xcodeLocatorOutput = try shellOut(to: xcodeLocatorCmd)
-            var allXcodes: String = ""
-            // Loop through supported Xcode versions and extract the path if present
-            for xcodeVersion in supportedXcodeVersions {
-                let xcodePathCmd = "printf '%s\n' \"\(xcodeLocatorOutput)\" | grep \"expanded=\(xcodeVersion)\" | sed -e 's,.*file://,,g' -e 's,/:.*,,g'"
-                let xcodePathOutput = try shellOut(to: xcodePathCmd)
-
-                if xcodePathOutput.count > 0 {
-                    allXcodes += "\n\(xcodePathOutput)"
-                }
-            }
-
-            // Returns an array of [/Path/To/Xcode.app/]
-            let xcodes = allXcodes.split(separator: "\n")
-            if xcodes.count == 0 {
-                print("warning: No Xcodes installed")
-            }
-            let needsInstalls = xcodes.filter {
-                xcode in
-                let bsPath = String(xcode + servicePath)
-                guard let link = try? FileManager.default.destinationOfSymbolicLink(atPath: bsPath) else {
-                   return true
-                }
-                guard link == installedBinPath else {
-                    return true
-                }
-                return false
-            }
-            hasUnlinkedXcodes = needsInstalls.count > 0
+            hasUnlinkedXcodes = try getXcodes(withBuildSystemInstalled: false).count > 0
         } catch {
             return .failure(.basic(error.localizedDescription))
         }
@@ -83,6 +52,28 @@ enum XcodeBuildSystemInstaller {
                 return .failure(.basic("failed to install. please see /var/log/install.log for more info"))
             }
         }
+        return .success(())
+    }
+
+    static func uninstallIfNecessary() -> Result<(), CommandError> {
+        do {
+            let needsUninstalls = try getXcodes(withBuildSystemInstalled: true)
+
+            for xcode in needsUninstalls {
+                let defaultBsTempPath = String(xcode + servicePath + ".default")
+                let defaultBsOriginalPath = String(xcode + servicePath)
+
+                guard FileManager.default.fileExists(atPath: defaultBsTempPath) else {
+                    return .failure(.basic("Default build system not found at temporary path: \(defaultBsTempPath)"))
+                }
+
+                try FileManager.default.removeItem(atPath: defaultBsOriginalPath)
+                try FileManager.default.moveItem(atPath: defaultBsTempPath, toPath: defaultBsOriginalPath)
+            }
+        } catch {
+            return .failure(.basic(error.localizedDescription))
+        }
+
         return .success(())
     }
 
@@ -100,6 +91,48 @@ enum XcodeBuildSystemInstaller {
         // self, or the repository_rule that defined it.
         // https://github.com/jerrymarino/xcbuildkit/blob/master/BUILD#L101
         return plistData["BUILD_COMMIT"] as? String
+    }
+
+    private static func getXcodes(withBuildSystemInstalled filterInstalled: Bool) throws -> [String] {
+        let bundle = Bundle.main
+        let buildkitBundlePath = bundle.path(forResource: "XCBuildKit", ofType: "bundle")!
+        let xcodeLocatorPath =  buildkitBundlePath + "/xcode-locator"
+        let installedAppDir = "/opt/XCBuildKit/XCBuildKit.app"
+        let installedBinPath =  installedAppDir + "/Contents/MacOS/BazelBuildService"
+
+        let xcodeLocatorCmd = xcodeLocatorPath + " 2>&1"
+        let xcodeLocatorOutput = try shellOut(to: xcodeLocatorCmd)
+        var allXcodes: String = ""
+        // Loop through supported Xcode versions and extract the path if present
+        for xcodeVersion in supportedXcodeVersions {
+            let xcodePathCmd = "printf '%s\n' \"\(xcodeLocatorOutput)\" | grep \"expanded=\(xcodeVersion)\" | sed -e 's,.*file://,,g' -e 's,/:.*,,g'"
+            let xcodePathOutput = try shellOut(to: xcodePathCmd)
+
+            if xcodePathOutput.count > 0 {
+                allXcodes += "\n\(xcodePathOutput)"
+            }
+        }
+
+        // Returns an array of [/Path/To/Xcode.app/]
+        let xcodes = allXcodes.split(separator: "\n").map { String($0) }
+        guard xcodes.count > 0 else {
+            print("warning: No Xcodes installed")
+            return []
+        }
+
+        // Based on what was requested in `filterInstalled` returns Xcodes with build system installed or Xcodes
+        // with build system not installed. See usage in `installIfNecessary` and `uninstallIfNecessary` above.
+        return xcodes.filter {
+            xcode in
+            let bsPath = String(xcode + servicePath)
+            guard let link = try? FileManager.default.destinationOfSymbolicLink(atPath: bsPath) else {
+                return filterInstalled ? false : true
+            }
+            guard link == installedBinPath else {
+                return filterInstalled ? false : true
+            }
+            return filterInstalled ? true : false
+        }
     }
 }
 

--- a/Sources/XCHammer/main.swift
+++ b/Sources/XCHammer/main.swift
@@ -311,6 +311,17 @@ struct InstallXcodeBuildSystemCommand: CommandProtocol {
     }
 }
 
+struct UninstallXcodeBuildSystemCommand: CommandProtocol {
+    let verb = "uninstall_xcode_build_system"
+    let function = "Uninstalls XCHammer's Xcode build system"
+
+    typealias Options = NoOptions<CommandError>
+
+    func run(_: Options) -> Result<(), CommandError> {
+        return XcodeBuildSystemInstaller.uninstallIfNecessary()
+    }
+}
+
 func main() {
     XCHammerLogger.initialize()
     let commands = CommandRegistry<CommandError>()
@@ -319,6 +330,7 @@ func main() {
     commands.register(ProcessIpaCommand())
     commands.register(InstallVFSCommand())
     commands.register(InstallXcodeBuildSystemCommand())
+    commands.register(UninstallXcodeBuildSystemCommand())
     commands.register(VersionCommand())
     commands.register(HelpCommand(registry: commands))
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,7 +67,7 @@ xchammer_dependencies()
 # https://github.com/bazelbuild/bazel/issues/1550
 git_repository(
     name = "xcbuildkit",
-    commit = "1e1155dc4aa9d7dc4260fb5c287acc0b299bbd76",
+    commit = "b2f0e4dd5a572b7029db3cf791d0897977f96a80",
     remote = "https://github.com/jerrymarino/xcbuildkit.git",
 )
 


### PR DESCRIPTION
Note: also bumping `xcbuildkit` to pick up latest changes

Adds uninstall cmd to put the original build system back. Effectively this https://github.com/jerrymarino/xcbuildkit/blob/master/utils/uninstall.sh but as an XCHammer cmd. This way we can dep on XCHammer and install/uninstall from here directly.

To test this build xchammer:
```sh
tools/bazelwrapper build //:xchammer 
```
then located the built app and execute the install cmd (we can run this from a rule action):
```sh
bazel-out/applebin_macos-darwin_x86_64-dbg-ST-639799358421/bin/xchammer_archive-root/xchammer.app/Contents/MacOS/xchammer uninstall_xcode_build_system
```
then note how things have changed on disk under the installed Xcodes:
```sh
ls -lahuT /Applications/Xcode*.app/Contents/SharedFrameworks/XCBuild.framework/PlugIns/XCBBuildService.bundle/Contents/MacOS

lrwxr-xr-x  1 root    staff    63B  7 Oct 10:51:12 2022 XCBBuildService -> /opt/XCBuildKit/XCBuildKit.app/Contents/MacOS/BazelBuildService
-rwxr-xr-x  1 thiago  staff   166K 21 Aug 01:06:18 2022 XCBBuildService.default
```
now, run the uninstall cmd this PR introduces:
```sh
bazel-out/applebin_macos-darwin_x86_64-dbg-ST-639799358421/bin/xchammer_archive-root/xchammer.app/Contents/MacOS/xchammer uninstall_xcode_build_system
```
and note how the og build service is back with the same `ls` cmd above. Meaning that the symlink should be gone and the temporary `.default` rename of the og build service should be undone.