### PR TITLE
Collect objc compiler flags from Bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,7 +67,7 @@ xchammer_dependencies()
 # https://github.com/bazelbuild/bazel/issues/1550
 git_repository(
     name = "xcbuildkit",
-    commit = "d747efbee7d47de67a2f1641b4163f4c11fa0551",
+    commit = "358d90a4a5c01ea5f8de3fda334c9c6375cb0073",
     remote = "https://github.com/jerrymarino/xcbuildkit.git",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,7 +67,7 @@ xchammer_dependencies()
 # https://github.com/bazelbuild/bazel/issues/1550
 git_repository(
     name = "xcbuildkit",
-    commit = "2de1d41bdd4b9eea60764800af1ed7fcd62eeed3",
+    commit = "d747efbee7d47de67a2f1641b4163f4c11fa0551",
     remote = "https://github.com/jerrymarino/xcbuildkit.git",
 )
 

--- a/sample/WorkspaceSource/WORKSPACE
+++ b/sample/WorkspaceSource/WORKSPACE
@@ -63,3 +63,9 @@ local_repository(
 
 gen_repo(name = "Some")
 
+load(
+    "@bazel_skylib//:workspace.bzl",
+    "bazel_skylib_workspace",
+)
+
+bazel_skylib_workspace()


### PR DESCRIPTION
Requires: https://github.com/jerrymarino/xcbuildkit/pull/53 

- [x] Bump `xcbuildkit` to main branch before landing

* Bump `xcbuildkit`
* Collect `clang` compiler flags and save to existing aspect's output mappings file
* Some changes in this PR are also prep work to do similar work to support Swift in a follow up