### PR TITLE
Collect swiftc compiler flags for indexing

### DIFF
--- a/BazelExtensions/xcode_configuration_provider.bzl
+++ b/BazelExtensions/xcode_configuration_provider.bzl
@@ -247,7 +247,9 @@ def _swift_cmd_line(target, src):
         if a.argv and a.mnemonic == "SwiftCompile" and src.path in a.argv:
             argv.append(a.argv)
 
-    if len(argv) != 1:
+    # Only fail if there was at least one SwiftCompile action
+    # In this case expects only a single argv collected
+    if len([a for a in target.actions if a.mnemonic == "SwiftCompile"]) > 0 and len(argv) != 1:
         fail("[ERROR] Source file {} referenced in multiple SwiftCompile actions.".format(src.path))
     argv = argv[0]
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,7 +67,7 @@ xchammer_dependencies()
 # https://github.com/bazelbuild/bazel/issues/1550
 git_repository(
     name = "xcbuildkit",
-    commit = "358d90a4a5c01ea5f8de3fda334c9c6375cb0073",
+    commit = "c5ad8ab7cd83a70678532dbc7b2397347d24deae",
     remote = "https://github.com/jerrymarino/xcbuildkit.git",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,7 +67,7 @@ xchammer_dependencies()
 # https://github.com/bazelbuild/bazel/issues/1550
 git_repository(
     name = "xcbuildkit",
-    commit = "c5ad8ab7cd83a70678532dbc7b2397347d24deae",
+    commit = "18a2b0e73d2e0cba759d5b4da24e47af106922d7",
     remote = "https://github.com/jerrymarino/xcbuildkit.git",
 )
 


### PR DESCRIPTION
Requires: https://github.com/jerrymarino/xcbuildkit/pull/54

* Implement `_swift_cmd_line` to collect compiler flags for `SwiftCompile` actions for a given source
* Bump `xcbuildkit`