### PR TITLE
Make infoplist output of build with Bazel script phase

### DIFF
--- a/Sources/XCHammer/XcodeGenProjectSpecExtensions.swift
+++ b/Sources/XCHammer/XcodeGenProjectSpecExtensions.swift
@@ -32,9 +32,9 @@ extension ProjectSpec.TargetSource : Hashable {
 }
 
 extension ProjectSpec.BuildScript {
-    init(path: String?, script: String, name: String? = nil) {
+    init(path: String?, outputFiles: [String] = [], script: String, name: String? = nil) {
         self.init(script: .script(script), name: name, inputFiles: [],
-                outputFiles: [], shell: nil, runOnlyWhenInstalling: false)
+                outputFiles: outputFiles, shell: nil, runOnlyWhenInstalling: false)
     }
 }
 

--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -1475,6 +1475,7 @@ public class XcodeTarget: Hashable, Equatable {
             if settings.testTargetName != nil {
                 settings.codeSigningAllowed = First("YES")
             }
+            settings.infoPlistFile = xcodeBuildableTargetSettings.infoPlistFile
         } else {
             sources = self.xcCompileableSources
             xcodeBuildableTargetSettings = self.settings
@@ -1500,7 +1501,12 @@ public class XcodeTarget: Hashable, Equatable {
             First("${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets")
         settings <>= getDeploymentTargetSettings()
 
-        let bazelScript = ProjectSpec.BuildScript(path: nil, script: getScriptContent(), name: "Bazel build")
+        let bazelScript = ProjectSpec.BuildScript(
+            path: nil,
+            outputFiles: [settings.infoPlistFile?.v ?? ""],
+            script: getScriptContent(),
+            name: "Bazel build"
+        )
 
         return ProjectSpec.Target(
             name: xcTargetName,


### PR DESCRIPTION
This fixes an issue where a fresh generated Xcode project would fail to build with Bazel if the `INFOPLIST_FILE` for a given target was not generated yet and placed under `bazel-out`. In that case we need the script phase that builds with Bazel to declare the plist as an output for it to proceed.